### PR TITLE
Add initial spacetime elements

### DIFF
--- a/memory-bank/task-history.md
+++ b/memory-bank/task-history.md
@@ -6,6 +6,7 @@ This file maintains a chronological record of tasks completed in the project, as
 
 | Date | Task | Branch | Summary File | Description |
 |------|------|--------|--------------|-------------|
+| 2025-03-21 | Add Initial Spacetime Elements | add-spacetime-elements | [task-summary-add-spacetime-elements.md](./task-summary-add-spacetime-elements.md) | Ported spacetime visualization from prototype to main Three.js scene with mass slider |
 | 2025-03-21 | Add Three.js from CDN | add-threejs | [task-summary-add-threejs.md](./task-summary-add-threejs.md) | Added Three.js from a CDN to the Vite project with TypeScript support |
 
 ## Purpose

--- a/memory-bank/task-summary-add-spacetime-elements.md
+++ b/memory-bank/task-summary-add-spacetime-elements.md
@@ -1,0 +1,60 @@
+# Task Summary: Add Initial Spacetime Elements
+
+## Task Description
+Create a new git branch and port the spacetime visualization from the prototype directory to the main Three.js scene in the src directory, replacing the rotating green cube with a spacetime grid and Earth visualization, and including the mass slider control.
+
+## Steps Completed
+
+1. Created a new git branch:
+   ```bash
+   git checkout -b add-spacetime-elements
+   ```
+
+2. Created the Satellite class in the src directory:
+   ```typescript
+   // src/Satellite.ts
+   import * as THREE from 'three';
+
+   export class Satellite extends THREE.Mesh {
+       clock: number;
+       clockRate: number;
+
+       constructor(geometry: THREE.SphereGeometry, material: THREE.MeshPhongMaterial) {
+           super(geometry, material);
+           this.clock = 0;
+           this.clockRate = 1;
+       }
+   }
+   ```
+
+3. Updated the main.ts file to:
+   - Import the Satellite class
+   - Add physics constants (G, c, etc.)
+   - Replace the rotating green cube with:
+     - A blue Earth sphere
+     - A deformable orange wireframe spacetime grid
+   - Add the mass slider UI element
+   - Implement the grid deformation function based on mass
+   - Add event listeners for the mass slider
+
+4. Updated the CSS in style.css to:
+   - Add styles for the UI container
+   - Add styles for the slider container
+   - Ensure proper positioning and appearance of UI elements
+
+## Result
+Successfully implemented the spacetime visualization with a mass slider control. The visualization shows how mass affects spacetime, with the grid deforming more as the mass increases. This visually demonstrates Einstein's theory of general relativity, where mass curves spacetime.
+
+## Key Technical Decisions
+- Ported only the essential elements from the prototype (Earth, grid, mass slider)
+- Omitted the satellites, receiver, and other sliders as requested
+- Maintained the same physics calculations and grid deformation algorithm
+- Adapted the UI to match the existing application style
+- Positioned the UI elements to work well with the Three.js scene
+
+## Notes and Improvements
+- The implementation provides a clear visualization of how mass affects spacetime
+- The mass slider allows for interactive exploration of different mass values
+- The grid deformation is properly scaled for visibility
+- The Earth sphere provides a reference point for the spacetime deformation
+- Future improvements could include adding the other sliders and elements from the prototype

--- a/memory-bank/task-summary-add-spacetime-elements.md
+++ b/memory-bank/task-summary-add-spacetime-elements.md
@@ -42,6 +42,11 @@ Create a new git branch and port the spacetime visualization from the prototype 
    - Add styles for the slider container
    - Ensure proper positioning and appearance of UI elements
 
+5. Updated the layout to match the prototype:
+   - Made the Three.js scene take up the entire window
+   - Positioned the UI controls in a box with a light gray background in the top left corner
+   - Simplified the HTML structure to remove unnecessary container elements
+
 ## Result
 Successfully implemented the spacetime visualization with a mass slider control. The visualization shows how mass affects spacetime, with the grid deforming more as the mass increases. This visually demonstrates Einstein's theory of general relativity, where mass curves spacetime.
 
@@ -57,4 +62,6 @@ Successfully implemented the spacetime visualization with a mass slider control.
 - The mass slider allows for interactive exploration of different mass values
 - The grid deformation is properly scaled for visibility
 - The Earth sphere provides a reference point for the spacetime deformation
+- The fullscreen layout provides a more immersive experience
+- The UI controls are easily accessible in the top left corner
 - Future improvements could include adding the other sliders and elements from the prototype

--- a/prototype/Satellite.ts
+++ b/prototype/Satellite.ts
@@ -1,0 +1,12 @@
+import * as THREE from 'three';
+
+export class Satellite extends THREE.Mesh {
+    clock: number;
+    clockRate: number;
+
+    constructor(geometry: THREE.SphereGeometry, material: THREE.MeshPhongMaterial) {
+        super(geometry, material);
+        this.clock = 0;
+        this.clockRate = 1;
+    }
+}

--- a/prototype/global.d.ts
+++ b/prototype/global.d.ts
@@ -1,0 +1,3 @@
+declare global {
+    const THREE: typeof import('three');
+}

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GPS Relativity Visualization</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="ui">
+        <div class="slider-container">
+            <label>Planet Mass (x10²⁴ kg):</label>
+            <input type="range" id="massSlider" min="1" max="10" value="5.972" step="0.1">
+            <span id="massValue">5.972</span>
+        </div>
+        <div class="slider-container">
+            <label>Satellite Clock Speed:</label>
+            <input type="range" id="clockSpeedSlider" min="0.9999" max="1.0001" step="0.00001" value="1">
+            <span id="clockSpeedValue">1.00000</span>
+        </div>
+        <div class="slider-container">
+            <label>Time Speed (x):</label>
+            <input type="range" id="timeSpeedSlider" min="1" max="1000000" value="1">
+            <span id="timeSpeedValue">1x</span>
+        </div>
+        <button id="correctButton">Set Correct Clock Speed</button>
+    </div>
+    <div id="info" class="hidden"></div>
+    <canvas id="canvas"></canvas>
+    <script type="module" src="dist/main.js"></script>
+</body>
+</html>

--- a/prototype/main.ts
+++ b/prototype/main.ts
@@ -1,0 +1,237 @@
+import * as THREE from 'three';
+
+import { Satellite } from './Satellite'; // Import Satellite class
+
+// Constants (real units, scaled for visualization)
+const G = 6.6743e-11; // m³ kg⁻¹ s⁻²
+const c = 299792458; // m/s
+const earthRadius = 1; // Visual radius
+const satelliteRadius = 3; // Exaggerated orbit radius
+const numSatellites = 4;
+const baseMass = 5.972e24; // Earth's mass in kg
+const baseSatelliteSpeed = 3870; // m/s (GPS satellite speed)
+
+// Scene setup
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x524940); // Set background color to white
+const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+const renderer = new THREE.WebGLRenderer({
+    canvas: document.getElementById('canvas') as HTMLCanvasElement,
+    antialias: true,  // Enable anti-aliasing for smoother rendering
+    alpha: true       // Support transparent background if needed
+});
+renderer.setSize(window.innerWidth, window.innerHeight);
+renderer.setPixelRatio(window.devicePixelRatio); // Use device pixel ratio for sharper rendering
+camera.position.set(5, 2, 8);
+camera.lookAt(0, 0, 0);
+
+// Add lighting
+// Directional light from upper left
+const directionalLight = new THREE.DirectionalLight(0xffffff, 1);
+directionalLight.position.set(-5, 5, 3); // Position in the upper left
+scene.add(directionalLight);
+
+// Add ambient light for some base illumination
+const ambientLight = new THREE.AmbientLight(0x404040, 0.5); // soft white light
+scene.add(ambientLight);
+
+// Earth
+const earthGeometry = new THREE.SphereGeometry(earthRadius, 32, 32);
+const earthMaterial = new THREE.MeshPhongMaterial({
+    color: 0x0066ff,
+    transparent: true,
+    opacity: 0.9,
+    shininess: 30
+});
+const earth = new THREE.Mesh(earthGeometry, earthMaterial);
+scene.add(earth);
+
+// Spacetime grid
+const gridSize = 10;
+const gridStep = 0.1;
+// Create a proper 3D surface grid
+const gridGeometry = new THREE.PlaneGeometry(gridSize, gridSize, gridSize / gridStep, gridSize / gridStep);
+const gridMaterial = new THREE.MeshBasicMaterial({
+    color: 0xdb7f23,
+    wireframe: true,
+    side: THREE.DoubleSide  // Make the grid visible from both sides
+});
+const grid = new THREE.Mesh(gridGeometry, gridMaterial);
+grid.rotation.x = -Math.PI / 2; // Rotate to make it horizontal (XZ plane)
+grid.position.y = -1.0; // Slightly below Earth
+scene.add(grid);
+
+// Add a flat grid helper for better spatial reference
+const gridHelper = new THREE.GridHelper(gridSize, gridSize / gridStep, 0x888888, 0xBBBBBB);
+gridHelper.position.y = -0.15; // Position slightly below the deformable grid
+// scene.add(gridHelper);
+
+// Satellites
+const satellites: Satellite[] = [];
+for (let i = 0; i < numSatellites; i++) {
+    const theta = (i / numSatellites) * Math.PI * 2;
+    const x = satelliteRadius * Math.cos(theta);
+    const y = satelliteRadius * Math.sin(theta);
+    const satelliteGeometry = new THREE.SphereGeometry(0.1, 16, 16);
+    const satelliteMaterial = new THREE.MeshPhongMaterial({
+        color: 0xff0000,
+        shininess: 80,
+        emissive: 0x330000 // Slight glow effect
+    });
+    const satellite = new Satellite(satelliteGeometry, satelliteMaterial);
+    satellite.position.set(x, y, 0);
+    scene.add(satellite);
+    satellites.push(satellite);
+}
+
+// Receiver
+const receiverGeometry = new THREE.BoxGeometry(0.2, 0.2, 0.2);
+const receiverMaterial = new THREE.MeshPhongMaterial({
+    color: 0x00ff00,
+    shininess: 60,
+    emissive: 0x003300 // Slight glow effect
+});
+const receiver = new THREE.Mesh(receiverGeometry, receiverMaterial);
+receiver.position.set(0, 0, earthRadius + 0.1); // Changed from -earthRadius to earthRadius to move to opposite side
+scene.add(receiver);
+
+// Signal lines
+const lineMaterial = new THREE.LineBasicMaterial({ color: 0xffffff });
+const lines: THREE.Line[] = [];
+for (let i = 0; i < numSatellites; i++) {
+    const lineGeometry = new THREE.BufferGeometry().setFromPoints([satellites[i].position, receiver.position]);
+    const line = new THREE.Line(lineGeometry, lineMaterial);
+    scene.add(line);
+    lines.push(line);
+}
+
+// UI Elements
+const massSlider = document.getElementById('massSlider') as HTMLInputElement;
+const clockSpeedSlider = document.getElementById('clockSpeedSlider') as HTMLInputElement;
+const timeSpeedSlider = document.getElementById('timeSpeedSlider') as HTMLInputElement;
+const correctButton = document.getElementById('correctButton') as HTMLButtonElement;
+const massValue = document.getElementById('massValue') as HTMLSpanElement;
+const clockSpeedValue = document.getElementById('clockSpeedValue') as HTMLSpanElement;
+const timeSpeedValue = document.getElementById('timeSpeedValue') as HTMLSpanElement;
+const infoDiv = document.getElementById('info') as HTMLDivElement;
+
+// Raycaster for hover
+const raycaster = new THREE.Raycaster();
+const mouse = new THREE.Vector2();
+
+// Simulation variables
+let simulationTime = 0;
+
+// Update spacetime grid
+function updateGrid(mass: number) {
+    const k = (mass * G) / (c * c) * 5e2; // Adjusted scaling for visibility
+    const positions = gridGeometry.attributes.position.array as Float32Array;
+    const epsilon = 0.5; // Smoothing factor
+    
+    for (let i = 0; i < positions.length; i += 3) {
+        const x = positions[i];
+        const z = positions[i + 1];
+        const r = Math.sqrt(x * x + z * z);
+        
+        // Use a softened potential to avoid sharp spike at center
+        positions[i + 2] = -k / (r + epsilon);
+    }
+    
+    // Log the center vertex z value
+    const widthSegments = gridSize / gridStep; // 100 segments
+    const vertexCountPerRow = widthSegments + 1; // 101 vertices per row
+    const centerRow = Math.floor(vertexCountPerRow / 2); // 50
+    const centerCol = Math.floor(vertexCountPerRow / 2); // 50
+    const centerVertexIndex = centerRow * vertexCountPerRow + centerCol; // 5100
+    const centerZIndex = centerVertexIndex * 3 + 2; // 15302
+    console.log('Center z:', positions[centerZIndex]);
+    
+    gridGeometry.attributes.position.needsUpdate = true;
+}
+// Calculate time dilation delta
+function calculateDelta(satellite: Satellite, mass: number): number {
+    const r = satellite.position.length();
+    const phiSat = -G * mass / r;
+    const phiReceiver = -G * mass / earthRadius;
+    const v = baseSatelliteSpeed / 1e6; // Scaled down for simulation
+    const delta = (phiSat - phiReceiver) / (c * c) - (v * v) / (2 * c * c);
+    return delta * 1e6; // Exaggerated for visibility
+}
+
+// Animation loop
+function animate() {
+    requestAnimationFrame(animate);
+
+    const timeSpeed = parseFloat(timeSpeedSlider.value);
+    const dt = (0.016 * timeSpeed) / 1e6; // Scaled for simulation
+    simulationTime += dt;
+
+    const mass = parseFloat(massSlider.value) * 1e24;
+
+    // Update satellite clocks
+    let maxDeltaT = 0;
+    for (let i = 0; i < numSatellites; i++) {
+        const delta = calculateDelta(satellites[i], mass);
+        const dtau = (1 + delta) * dt;
+        satellites[i].clock += satellites[i].clockRate * dtau;
+        const deltaT = Math.abs(satellites[i].clock - simulationTime);
+        maxDeltaT = Math.max(maxDeltaT, deltaT);
+    }
+
+    // Estimate position error
+    const positionError = c * maxDeltaT; // Meters
+
+    // Update lines
+    for (let i = 0; i < numSatellites; i++) {
+        lines[i].geometry.setFromPoints([satellites[i].position, receiver.position]);
+    }
+
+    renderer.render(scene, camera);
+
+    // Hover effect
+    raycaster.setFromCamera(mouse, camera);
+    const intersects = raycaster.intersectObject(receiver);
+    if (intersects.length > 0) {
+        infoDiv.classList.remove('hidden');
+        infoDiv.style.left = `${mouse.x * window.innerWidth / 2 + window.innerWidth / 2 + 10}px`;
+        infoDiv.style.top = `${-mouse.y * window.innerHeight / 2 + window.innerHeight / 2 + 10}px`;
+        infoDiv.innerHTML = `Position Calculation:<br>Using signals from ${numSatellites} satellites.<br>Current Error: ${positionError.toFixed(2)} meters`;
+    } else {
+        infoDiv.classList.add('hidden');
+    }
+}
+animate();
+
+// Event listeners
+massSlider.addEventListener('input', () => {
+    massValue.textContent = parseFloat(massSlider.value).toFixed(3);
+    updateGrid(parseFloat(massSlider.value) * 1e24);
+});
+
+clockSpeedSlider.addEventListener('input', () => {
+    clockSpeedValue.textContent = parseFloat(clockSpeedSlider.value).toFixed(5);
+    const rate = parseFloat(clockSpeedSlider.value);
+    satellites.forEach(sat => sat.clockRate = rate);
+});
+
+timeSpeedSlider.addEventListener('input', () => {
+    timeSpeedValue.textContent = `${timeSpeedSlider.value}x`;
+});
+
+correctButton.addEventListener('click', () => {
+    const mass = parseFloat(massSlider.value) * 1e24;
+    for (let i = 0; i < numSatellites; i++) {
+        const delta = calculateDelta(satellites[i], mass);
+        satellites[i].clockRate = 1 - delta;
+    }
+    clockSpeedValue.textContent = satellites[0].clockRate.toFixed(5);
+    clockSpeedSlider.value = satellites[0].clockRate.toString();
+});
+
+document.addEventListener('mousemove', (event) => {
+    mouse.x = (event.clientX / window.innerWidth) * 2 - 1;
+    mouse.y = -(event.clientY / window.innerHeight) * 2 + 1;
+});
+
+// Initial grid setup
+updateGrid(baseMass);

--- a/prototype/style.css
+++ b/prototype/style.css
@@ -1,0 +1,57 @@
+body {
+    margin: 0;
+    overflow: hidden;
+    font-family: Arial, sans-serif;
+}
+
+canvas {
+    display: block;
+}
+
+#ui {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    background: rgba(255, 255, 255, 0.8);
+    padding: 10px;
+    border-radius: 5px;
+}
+
+.slider-container {
+    margin: 5px 0;
+}
+
+label {
+    font-size: 14px;
+    margin-right: 5px;
+}
+
+input[type="range"] {
+    vertical-align: middle;
+}
+
+span {
+    font-size: 14px;
+    margin-left: 5px;
+    min-width: 50px;
+    display: inline-block;
+}
+
+button {
+    margin-top: 10px;
+    padding: 5px 10px;
+    cursor: pointer;
+}
+
+#info {
+    position: absolute;
+    background: rgba(0, 0, 0, 0.8);
+    color: white;
+    padding: 10px;
+    border-radius: 5px;
+    pointer-events: none;
+}
+
+.hidden {
+    display: none;
+}

--- a/src/Satellite.ts
+++ b/src/Satellite.ts
@@ -1,0 +1,12 @@
+import * as THREE from 'three';
+
+export class Satellite extends THREE.Mesh {
+    clock: number;
+    clockRate: number;
+
+    constructor(geometry: THREE.SphereGeometry, material: THREE.MeshPhongMaterial) {
+        super(geometry, material);
+        this.clock = 0;
+        this.clockRate = 1;
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,34 +1,27 @@
 import './style.css'
-import typescriptLogo from './typescript.svg'
-import viteLogo from '/vite.svg'
-import { setupCounter } from './counter.ts'
 // Import Three.js as ES module
 import * as THREE from 'three'
+import { Satellite } from './Satellite'
 
-// Create a container for the Three.js canvas and the original content
+// Constants (real units, scaled for visualization)
+const G = 6.6743e-11; // m³ kg⁻¹ s⁻²
+const c = 299792458; // m/s
+const earthRadius = 1; // Visual radius
+const baseMass = 5.972e24; // Earth's mass in kg
+
+// Create a container for the Three.js canvas
 document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
   <div class="container">
     <div class="three-container" id="three-container"></div>
-    <div class="content">
-      <a href="https://vite.dev" target="_blank">
-        <img src="${viteLogo}" class="logo" alt="Vite logo" />
-      </a>
-      <a href="https://www.typescriptlang.org/" target="_blank">
-        <img src="${typescriptLogo}" class="logo vanilla" alt="TypeScript logo" />
-      </a>
-      <h1>Vite + TypeScript + Three.js</h1>
-      <div class="card">
-        <button id="counter" type="button"></button>
+    <div class="ui-container">
+      <div class="slider-container">
+        <label>Planet Mass (x10²⁴ kg):</label>
+        <input type="range" id="massSlider" min="1" max="10" value="5.972" step="0.1">
+        <span id="massValue">5.972</span>
       </div>
-      <p class="read-the-docs">
-        Click on the Vite and TypeScript logos to learn more
-      </p>
     </div>
   </div>
 `
-
-// Set up the counter
-setupCounter(document.querySelector<HTMLButtonElement>('#counter')!)
 
 // Set up Three.js scene
 const setupThreeScene = (): void => {
@@ -46,39 +39,82 @@ const setupThreeScene = (): void => {
     0.1,
     1000
   )
-  camera.position.z = 5
+  camera.position.set(5, 2, 8)
+  camera.lookAt(0, 0, 0)
 
   // Create renderer
   const renderer = new THREE.WebGLRenderer({ antialias: true })
   renderer.setSize(container.clientWidth, container.clientHeight)
   container.appendChild(renderer.domElement)
 
-  // Create a cube
-  const geometry = new THREE.BoxGeometry(2, 2, 2)
-  const material = new THREE.MeshStandardMaterial({
-    color: 0x00ff00,
-    metalness: 0.3,
-    roughness: 0.4,
-  })
-  const cube = new THREE.Mesh(geometry, material)
-  scene.add(cube)
-
   // Add lights
-  const ambientLight = new THREE.AmbientLight(0xffffff, 0.5)
+  const ambientLight = new THREE.AmbientLight(0x404040, 0.5)
   scene.add(ambientLight)
 
   const directionalLight = new THREE.DirectionalLight(0xffffff, 1)
-  directionalLight.position.set(5, 5, 5)
+  directionalLight.position.set(-5, 5, 3)
   scene.add(directionalLight)
+
+  // Earth
+  const earthGeometry = new THREE.SphereGeometry(earthRadius, 32, 32)
+  const earthMaterial = new THREE.MeshPhongMaterial({
+    color: 0x0066ff,
+    transparent: true,
+    opacity: 0.9,
+    shininess: 30
+  })
+  const earth = new THREE.Mesh(earthGeometry, earthMaterial)
+  scene.add(earth)
+
+  // Spacetime grid
+  const gridSize = 10
+  const gridStep = 0.1
+  // Create a proper 3D surface grid
+  const gridGeometry = new THREE.PlaneGeometry(gridSize, gridSize, gridSize / gridStep, gridSize / gridStep)
+  const gridMaterial = new THREE.MeshBasicMaterial({
+    color: 0xdb7f23,
+    wireframe: true,
+    side: THREE.DoubleSide  // Make the grid visible from both sides
+  })
+  const grid = new THREE.Mesh(gridGeometry, gridMaterial)
+  grid.rotation.x = -Math.PI / 2 // Rotate to make it horizontal (XZ plane)
+  grid.position.y = -1.0 // Slightly below Earth
+  scene.add(grid)
+
+  // Update spacetime grid
+  function updateGrid(mass: number) {
+    const k = (mass * G) / (c * c) * 5e2 // Adjusted scaling for visibility
+    const positions = gridGeometry.attributes.position.array as Float32Array
+    const epsilon = 0.5 // Smoothing factor
+    
+    for (let i = 0; i < positions.length; i += 3) {
+      const x = positions[i]
+      const z = positions[i + 1]
+      const r = Math.sqrt(x * x + z * z)
+      
+      // Use a softened potential to avoid sharp spike at center
+      positions[i + 2] = -k / (r + epsilon)
+    }
+    
+    gridGeometry.attributes.position.needsUpdate = true
+  }
+
+  // Mass slider elements
+  const massSlider = document.getElementById('massSlider') as HTMLInputElement
+  const massValue = document.getElementById('massValue') as HTMLSpanElement
+  
+  // Initialize grid with default mass
+  updateGrid(parseFloat(massSlider.value) * 1e24)
+  
+  massSlider.addEventListener('input', () => {
+    const massVal = parseFloat(massSlider.value)
+    massValue.textContent = massVal.toFixed(3)
+    updateGrid(massVal * 1e24)
+  })
 
   // Animation loop
   const animate = (): void => {
     requestAnimationFrame(animate)
-
-    // Rotate the cube
-    cube.rotation.x += 0.01
-    cube.rotation.y += 0.01
-
     renderer.render(scene, camera)
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,14 +11,12 @@ const baseMass = 5.972e24; // Earth's mass in kg
 
 // Create a container for the Three.js canvas
 document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
-  <div class="container">
-    <div class="three-container" id="three-container"></div>
-    <div class="ui-container">
-      <div class="slider-container">
-        <label>Planet Mass (x10²⁴ kg):</label>
-        <input type="range" id="massSlider" min="1" max="10" value="5.972" step="0.1">
-        <span id="massValue">5.972</span>
-      </div>
+  <div class="three-container" id="three-container"></div>
+  <div class="ui-container">
+    <div class="slider-container">
+      <label>Planet Mass (x10²⁴ kg):</label>
+      <input type="range" id="massSlider" min="1" max="10" value="5.972" step="0.1">
+      <span id="massValue">5.972</span>
     </div>
   </div>
 `

--- a/src/style.css
+++ b/src/style.css
@@ -54,10 +54,40 @@ h1 {
 /* Three.js container */
 .three-container {
   width: 100%;
-  height: 300px;
+  height: 400px;
   border-radius: 8px;
   overflow: hidden;
   background-color: #1a1a1a;
+}
+
+/* UI container */
+.ui-container {
+  background: rgba(30, 30, 30, 0.8);
+  padding: 1rem;
+  border-radius: 8px;
+  margin-top: 1rem;
+}
+
+/* Slider container */
+.slider-container {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.5rem;
+  gap: 0.5rem;
+}
+
+.slider-container label {
+  min-width: 180px;
+  font-size: 0.9rem;
+}
+
+.slider-container input[type="range"] {
+  flex: 1;
+}
+
+.slider-container span {
+  min-width: 50px;
+  text-align: right;
 }
 
 /* Content container */
@@ -77,6 +107,10 @@ h1 {
   
   .content {
     flex: 1;
+  }
+  
+  .ui-container {
+    margin-top: 0;
   }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -24,94 +24,59 @@ a:hover {
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+  overflow: hidden;
+  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
 }
 
 #app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
-  width: 100%;
-}
-
-/* Container for Three.js and content */
-.container {
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-  width: 100%;
+  width: 100vw;
+  height: 100vh;
+  position: relative;
 }
 
 /* Three.js container */
 .three-container {
   width: 100%;
-  height: 400px;
-  border-radius: 8px;
-  overflow: hidden;
-  background-color: #1a1a1a;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
 }
 
 /* UI container */
 .ui-container {
-  background: rgba(30, 30, 30, 0.8);
-  padding: 1rem;
-  border-radius: 8px;
-  margin-top: 1rem;
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  background: rgba(255, 255, 255, 0.8);
+  padding: 10px;
+  border-radius: 5px;
+  z-index: 10;
 }
 
 /* Slider container */
 .slider-container {
+  margin: 5px 0;
   display: flex;
   align-items: center;
-  margin-bottom: 0.5rem;
   gap: 0.5rem;
 }
 
 .slider-container label {
+  font-size: 14px;
   min-width: 180px;
-  font-size: 0.9rem;
 }
 
 .slider-container input[type="range"] {
-  flex: 1;
+  vertical-align: middle;
+  width: 150px;
 }
 
 .slider-container span {
+  font-size: 14px;
+  margin-left: 5px;
   min-width: 50px;
-  text-align: right;
-}
-
-/* Content container */
-.content {
-  width: 100%;
-}
-
-@media (min-width: 768px) {
-  .container {
-    flex-direction: row;
-  }
-  
-  .three-container {
-    flex: 1;
-    height: 400px;
-  }
-  
-  .content {
-    flex: 1;
-  }
-  
-  .ui-container {
-    margin-top: 0;
-  }
+  display: inline-block;
 }
 
 .logo {


### PR DESCRIPTION
This PR adds the initial spacetime elements from the prototype to the main Three.js scene. It replaces the rotating green cube with a spacetime visualization that includes a blue Earth sphere and a deformable orange wireframe grid that responds to mass changes. It also adds a mass slider UI control in the top left corner of the screen to adjust the mass and see how it affects spacetime curvature.